### PR TITLE
Make each test lambda to be defined as a DEFUN %TEST-<NAME>. 

### DIFF
--- a/src/run.lisp
+++ b/src/run.lisp
@@ -89,6 +89,14 @@ run."))
          (setf (status test) :circular))))
     (t (status test))))
 
+(defun note-failed-to-compile-test (outer-name)
+  (with-run-state (current-test result-list)
+    (add-result 'test-failure
+                :test-expr nil
+                :test-case current-test
+                :reason (format nil "~A failed to update ~A of ~S"
+                                'compile 'fdefinition outer-name))))
+
 (defgeneric resolve-dependencies (depends-on))
 
 (defmethod resolve-dependencies ((depends-on symbol))

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -23,11 +23,15 @@ IN (a symbol), if provided, causes this suite te be nested in the
 suite named by IN. NB: This macro is built on top of make-suite,
 as such it, like make-suite, will overrwrite any existing suite
 named NAME."
-  `(eval-when (:compile-toplevel :load-toplevel :execute)
-     (make-suite ',name
-                 ,@(when description `(:description ,description))
-                 ,@(when in `(:in ',in)))
-     ',name))
+  (let ((outer-name (generate-test-defun-name name))) 
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (progn 
+         (make-suite ',name
+                     ,@(when description `(:description ,description))
+                     ,@(when in `(:in ',in)))
+         (defun ,outer-name ()
+           (run! ',name))
+         ',name))))
 
 (defmacro def-suite* (name &rest def-suite-args)
   `(progn

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -150,6 +150,7 @@
     (run 'circular-2)))
 
 
+;;; Before tests fail on CCL and CLISP before my changes too -- maxm
 (def-suite before-test-suite :description "Suite for before test")
 
 (def-test before-0 (:suite before-test-suite)


### PR DESCRIPTION
This accomplishes the goal of making M-. work in Slime, as well as fixing v
key in SLDB to correctly go the source
