### PR TITLE
Shut up warnings about unknown *SUITE* variable.

### DIFF
--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -53,6 +53,8 @@ will overrwrite any existing suite named `NAME`."
       (when (gethash test-name (tests s))
         (remhash test-name (tests s))))))
 
+(declaim (special *suite*))
+
 (defun make-suite (name &key description ((:in parent-suite) *suite*) fixture)
   "Create a new test suite object.
 

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -45,6 +45,8 @@ named KEY in the *TEST* hash table."
       (ensure-list name)
     `(def-test ,name (,@args) ,@body)))
 
+(declaim (special *suite*))
+
 (defmacro def-test (name (&key (suite nil suite-p)
                                fixture
                                (compile-at :run-time)


### PR DESCRIPTION
Either this way, or moving definitions around.  Also, MAKE-SUITE and _SUITE_ depend on each other, so it's needed there as well.
