### PR TITLE
Add IS-ALL macro.

### DIFF
--- a/src/check.lisp
+++ b/src/check.lisp
@@ -209,6 +209,10 @@ REASON-ARGS is provided, is generated based on the form of TEST:
              (loop for (expr value) on clauses by #'cddr
                    collect `(is (,predicate ,expr ,value)))))))
 
+(defmacro is-all (&body clauses)
+  "The input is a list of tests. Generates (is ,clause) for each one."
+  `(progn ,@(mapcar (lambda (clause) `(is ,clause)) clauses)))
+
 (defmacro is-true (condition &rest reason-args)
   "Like IS this check generates a pass if CONDITION returns true
   and a failure if CONDITION returns false. Unlike IS this check

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -43,6 +43,7 @@
    ;; running checks
    #:is
    #:is-every
+   #:is-all
    #:is-true
    #:is-false
    #:signals


### PR DESCRIPTION
Hi, this adds a macro to remove a bit of repetition, i.e. it allows us to write:

    (is-all
      (eq 1 1)
      (eq 2 2))

instead of repeating `IS` all the time.