### PR TITLE
Indicate test failures with return value.

### DIFF
--- a/src/run.lisp
+++ b/src/run.lisp
@@ -234,8 +234,10 @@ run."))
 
 (defun explain! (result-list)
   "Explain the results of RESULT-LIST using a
-detailed-text-explainer with output going to *test-dribble*"
-  (explain (make-instance 'detailed-text-explainer) result-list *test-dribble*))
+detailed-text-explainer with output going to *test-dribble*.
+Return a boolean indicating whether no tests failed."
+  (explain (make-instance 'detailed-text-explainer) result-list *test-dribble*)
+  (notany #'test-failure-p result-list))
 
 (defun debug! (&optional (test-spec *suite*))
   "Calls (run! test-spec) but enters the debugger if any kind of error happens."

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -254,3 +254,11 @@
   (for-all (((a b) (dummy-mv-generator)))
     (is (= 1 a))
     (is (= 1 b))))
+
+(def-test return-values ()
+  "Return values indicate test failures."
+  (is-true (with-*test-dribble* nil (explain! (run 'is1))))
+  (is-true (with-*test-dribble* nil (run! 'is1)))
+
+  (is-false (with-*test-dribble* nil (explain! (run 'is2))))
+  (is-false (with-*test-dribble* nil (run! 'is2))))


### PR DESCRIPTION
This changes the return values of the `FOO!` functions to indicate whether all tests succeeded. Why? Because otherwise that has to repeated every time the tests have be integrated into some toolchain, like I recently did for Travis CI. Since ASDF doesn't help with `TEST-SYSTEM` (grr), having a single function like `RUN!` return an "exit status" we can use immediately makes the code much smaller and doesn't require exporting `TEST-PASSED-P` (although I'd rather that and `TEST-FAILURE-P` were exported as well).

Single test case is added as well. I assume nobody relied on the undefined return value of `EXPLAIN!`, so IMO this is safe.