### PR TITLE
Add DEADLINE check for time limits

### DIFF
--- a/src/check.lisp
+++ b/src/check.lisp
@@ -277,6 +277,17 @@ fails."
             :reason (format nil "Test didn't finish")
             :test-expr ',body)))))
 
+(defmacro deadline ((ms) &body body)
+  "Generates a pass if the body finishes within the given number of
+   milliseconds."
+  (with-gensyms (duration)
+    `(let ((,duration (internal->ms (timer ,@body))))
+       (if (<= ,duration ,ms)
+           (add-result 'test-passed :test-expr ',body)
+           (process-failure
+            :reason (format nil "Test supposed to finish within ~Dms, but took ~Dms" ,ms ,duration)
+            :test-expr ',body)))))
+
 (defmacro pass (&rest message-args)
   "Simply generate a PASS."
   `(add-result 'test-passed

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -47,6 +47,7 @@
    #:is-false
    #:signals
    #:finishes
+   #:deadline
    #:skip
    #:pass
    #:fail

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -195,6 +195,18 @@ which is the concatenation of \"WITH-\" NAME. BINDER is built as
             ,@body))
        ',name)))
 
+(defmacro timer (&body body)
+  "Return the number of internal real time units that BODY takes to run to
+   completion."
+  (with-gensyms (beg)
+    `(let ((,beg (get-internal-real-time)))
+       ,@body
+       (- (get-internal-real-time) ,beg))))
+
+(defun internal->ms (internal)
+  "Convert internal real time units to milliseconds."
+  (floor (/ internal #.(/ internal-time-units-per-second 1000))))
+
 ;; Copyright (c) 2002-2006, Edward Marco Baringer
 ;; All rights reserved.
 ;;

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -46,6 +46,17 @@
    (signals error
     (error "an error"))))
 
+(def-test deadline1 (:suite test-suite)
+  (deadline (500)
+    (sleep 1)))
+
+(def-test deadline ()
+  (with-test-results (results deadline1)
+    (is (= 1 (length results)))
+    (is (test-failure-p (first results))))
+  (deadline (1250)
+    (sleep 1)))
+
 (def-test pass ()
   (pass))
 


### PR DESCRIPTION
I needed some timing checks for making sure that some parallelism constructs don't block until necessary; perhaps others would find them useful as well.