### PR TITLE
Thread support

### DIFF
--- a/fiveam-and-bordeaux-threads.asd
+++ b/fiveam-and-bordeaux-threads.asd
@@ -1,0 +1,8 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :fiveam-and-bordeaux-threads
+  :author "Jan Moringen <jmoringe@techfak.uni-bielefeld.de>"
+  :version (:read-file-form "version.sexp")
+  :depends-on (:fiveam :alexandria :bordeaux-threads)
+  :pathname "src/"
+  :components ((:file "threads")))

--- a/src/check.lisp
+++ b/src/check.lisp
@@ -89,7 +89,9 @@ when appropiate."))
   (:method ((o t)) nil)
   (:method ((o test-skipped)) t))
 
-(defun add-result (result-type &rest make-instance-args)
+(defgeneric add-result (result-type &rest make-instance-args))
+
+(defmethod add-result ((result-type t) &rest make-instance-args)
   "Create a TEST-RESULT object of type RESULT-TYPE passing it the
   initialize args MAKE-INSTANCE-ARGS and adds the resulting
   object to the list of test results."

--- a/src/threads.lisp
+++ b/src/threads.lisp
@@ -1,0 +1,65 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(in-package :it.bese.fiveam)
+
+;;; We want to make something like the following possible:
+
+;; (test foo
+;;   (let ((thread (bt:make-thread (lambda () (is (= 7 6))))))
+;;     (is (= 1 5))
+;;     (bt:join-thread thread)))
+
+;;; Result management
+
+(defvar *result-lock*)
+
+(defvar *main-thread*)
+
+(defmethod call-environment-binding :around
+    ((name (eql 'run-state)) (bindings list) (style t) (thunk t))
+  (let* ((*result-lock* (bt:make-lock "Result lock"))
+         (*main-thread* nil)
+         (bt:*default-wrappers*
+          (list*
+           (lambda (next)
+             ;; Capture in parent thread.
+             (let ((main-thread      (bt:current-thread)) ; TODO make a list of special variables
+                   (debug-on-failure *debug-on-failure*)
+                   (debug-on-error   *debug-on-error*)
+                   (result-lock      *result-lock*))
+               (lambda ()
+                 ;; Establish in child thread.
+                 (let ((*main-thread*      main-thread)
+                       (*debug-on-failure* debug-on-failure)
+                       (*debug-on-error*   debug-on-error)
+                       (*result-lock*      result-lock))
+                   (handler-bind
+                       ((check-failure
+                         (lambda (e)
+                           (declare (ignore e))
+                           (unless *debug-on-failure*
+                             (invoke-restart
+                              (find-restart 'ignore-failure)))))
+                        (error
+                         (lambda (e)
+                           (unless (or *debug-on-error*
+                                       (typep e 'check-failure))
+                             ;; TODO make a function; also in run-test-lambda
+                             (locally (declare (special current-test))
+                               (add-result 'unexpected-test-failure
+                                           :test-expr nil
+                                           :test-case current-test
+                                           :reason (format nil "Unexpected Error: ~S~%~A." e e)
+                                           :condition e))
+                             (abort)))))
+                     (funcall next))))))
+           bt:*default-wrappers*)))
+    (call-next-method)))
+
+(defmethod add-result :around ((result-type t) &rest make-instance-args)
+  (bt:with-lock-held (*result-lock*)
+    (if *main-thread*
+        (bt:interrupt-thread
+         *main-thread*
+         (lambda () (apply #'add-result result-type make-instance-args)))
+        (call-next-method))))


### PR DESCRIPTION
I would like to propose the attached extension which allows `is` to work with threads as long as they are created in the current `test`. This feature depends on bordeaux-threads (actually bordeaux-threads with [PR 19](https://github.com/sionescu/bordeaux-threads/pull/19)) and is thus provided in a separate ASDF system. Another reason for not loading thread support unconditionally is the need for locking when gathering test results which may have a performance impact. The attached implementation is just a proof of concept. I can add tests and improve the code if there is interest in this feature.