### PR TITLE
Declare types of *ON-{ERROR,FAILURE}*

### DIFF
--- a/src/run.lisp
+++ b/src/run.lisp
@@ -33,6 +33,11 @@
 ;;;; The functions RUN!, !, !! and !!! are convenient wrappers around
 ;;;; RUN and EXPLAIN.
 
+(deftype on-problem-action ()
+  '(member :debug :backtrace nil))
+
+(declaim (type on-problem-action *on-error* *on-failure*))
+
 (defvar *on-error* nil
   "The action to perform on error:
 - :DEBUG if we should drop into the debugger


### PR DESCRIPTION
This helps catching typos and such for some implementations and compiler policies and should do no harm otherwise.

As a concrete example, I work with a `((debug 3) (safety 3))` policy in SBCL and accidentally did `(setf 5am:*on-error* :break)`. With this patch, the error would have been caught immediately.
