### PR TITLE
Change the symbol 'NIL to lower case

### DIFF
--- a/src/run.lisp
+++ b/src/run.lisp
@@ -328,7 +328,7 @@ performed by the !, !! and !!! functions."
 SUMMARY can be :END to print a summary at the end, :SUITE to print it
 after each suite or NIL to skip explanations."
   (check-type summary (member nil :suite :end))
-  (loop :for suite :in (cons 'NIL (sort (copy-list *toplevel-suites*) #'string<=))
+  (loop :for suite :in (cons 'nil (sort (copy-list *toplevel-suites*) #'string<=))
         :for results := (if (suite-emptyp suite) nil (run suite))
         :when (consp results)
           :collect results :into all-results

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -73,8 +73,8 @@ Overrides any existing suite named NAME."
 
 (eval-when (:load-toplevel :execute)
   (setf *suite*
-        (setf (get-test 'NIL)
-              (make-suite 'NIL :description "Global Suite"))))
+        (setf (get-test 'nil)
+              (make-suite 'nil :description "Global Suite"))))
 
 (defun list-all-suites ()
   "Returns an unordered LIST of all suites."


### PR DESCRIPTION
This trivial change allow FiveAM to be compatible with Allegro CL Modern mode (see http://franz.com/support/documentation/current/doc/case.htm) and is transparent to others CL implementations.

(asdf:test-system :fiveam) returns 53 successful tests on
- Allegro CL 10 Modern and ANSI modes
- SBCL 1.3.5