### PR TITLE
Improve output of test names

### DIFF
--- a/src/run.lisp
+++ b/src/run.lisp
@@ -196,6 +196,8 @@ run."))
                          (handler-case
                              (let ((*readtable* (copy-readtable))
                                    (*package* (runtime-package test)))
+                               (when *print-names*
+                                   (format *test-dribble* "~% Running test ~A " (name test)))
                                (if (collect-profiling-info test)
                                    ;; Timing info doesn't get collected ATM, we need a portable library
                                    ;; (setf (profiling-info test) (collect-timing (test-lambda test)))
@@ -226,8 +228,6 @@ run."))
   !!, !!!"))
 
 (defmethod %run ((test test-case))
-  (when *print-names*
-    (format *test-dribble* "~% Running test ~A " (name test)))
   (run-resolving-dependencies test))
 
 (defmethod %run ((tests list))


### PR DESCRIPTION
Previously, if a test ran it's dependencies, the results of the dependency would get combine with the dependent's results test.  Additionally, this pull request changes the indentation of the names of test cases and suites to show the hierarchy.

The below script can show the change in behavior before and after of the printing orderived issue.

```common_lisp
(ql:quickload :fiveam)
(5am:in-suite* foo)
(5am:test bar (5am:is (= 1 1)))
(5am:test (baz :depends-on bar) (5am:is (= 1 1)))
(5am:run! 'foo)
```

The previous behavior was:
```
Running test suite FOO
 Running test BAZ ..
 Running test BAR 
 Did 2 checks.
    Pass: 2 (100%)
    Skip: 0 ( 0%)
    Fail: 0 ( 0%)
```

The updated behavior is:
```
Running test suite FOO
 Running test BAR .
 Running test BAZ .
 Did 2 checks.
    Pass: 2 (100%)
    Skip: 0 ( 0%)
    Fail: 0 ( 0%)
```