### PR TITLE
Use upto date version of cl-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ notifications:
     skip_join: true
 
 install:
-  - curl -L https://raw.githubusercontent.com/sionescu/cl-travis/master/install.sh | sh
+  - curl -L https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh
   - cl -e "(cl:in-package :cl-user)
            (dolist (p '(:alexandria))
              (ql:quickload p :verbose t))"


### PR DESCRIPTION
A fix for the Allegro licenses issue has been added to master on cl-travis, so this will switch from using the fork at [sionescu/cl-travis](https://github.com/sionescu/cl-travis) to using the master version.