### PR TITLE
Create Roswell script to run tests under Fiveam

### DIFF
--- a/roswell/fiveam-run.ros
+++ b/roswell/fiveam-run.ros
@@ -1,0 +1,49 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+
+(unless (find-package :uiop)
+  (ql:quickload :uiop :silent t))
+
+(ql:quickload :fiveam :silent t)
+
+(defun show-help ()
+  (format t "Usage: fiveam-run [options] <test cases and suites>...~%~
+             Loads the system with quicklisp then calls fiveam:run! with ~
+             a list of the rest of the arguments.~%~
+             Each test case are parsed with ~
+             read-from-string, so a list of systems can be read and ~
+             package-indentified symbols can be used~%~
+             Options~%~
+             --help|-h              - shows this help message
+             --quickload|-l <sytem> - loads the system or list of ~
+             systems~%")
+  (uiop:quit 2))
+
+(defun main (&rest argv)
+  (if (> 1 (length argv))
+    (show-help))
+  (let ((load-systems nil) (tests nil))
+    (loop :with skip = nil
+          :for arg-list :on argv
+          :for arg = (car arg-list)
+          :if (not skip)
+            :do (cond
+                  ((or (equal "--quickload" arg) (equal "-l" arg))
+                       (setf load-systems (cons (second arg-list) load-systems))
+                       (setf skip t))
+                  ((or (equal "--help" arg) (equal "-h" arg)))
+                  (t (setf tests (cons arg tests))))
+          :else
+            :do (setf skip nil))
+    (handler-case
+      (progn
+        (if load-systems
+          (ql:quickload load-systems :verbose t))
+        (uiop:quit (if (5am:run! (map 'list #'read-from-string tests))
+                       0 1)))
+      (error (ex)
+        (format t "Error occured: ~A~%" ex)
+        (uiop:quit 2)))))


### PR DESCRIPTION
Roswell supports loading scripts when installing packages from Quicklisp.  This pull request adds a Roswell script to run Fiveam tests.  This script simplifies using Fiveam from Travis and should allow running tests from other platforms like Appveyor or CircleCI.  Also, Roswell currently encourages use of Prove instead of Fiveam, I think because Prove has a similar test script setup while Fiveam doesn't.
Usage:
```yaml
install:
  - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh
  - ros install fiveam

script:
  - ros exec fiveam-run -l <ql system> <tests...>
```
where `system` is a system to load with quicklisp and `tests...` are names of tests to run with fiveam:run!

It's currently tested at https://travis-ci.org/neil-lindquist/fiveam-roswell-tests/  It seemed easier to just make a separate test repository for the script than to try to merge it with fiveam's cl-travis based tests.
  