### PR TITLE
Add file attributes for Genera

### DIFF
--- a/fiveam.asd
+++ b/fiveam.asd
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Base: 10; -*-
 
 #.(unless (or #+asdf3.1 (version<= "3.1" (asdf-version)))
     (error "You need ASDF >= 3.1 to load this system correctly."))

--- a/src/check.lisp
+++ b/src/check.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/classes.lisp
+++ b/src/classes.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/explain.lisp
+++ b/src/explain.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/fixture.lisp
+++ b/src/fixture.lisp
@@ -1,4 +1,4 @@
-;; -*- lisp -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: CL-USER; Base: 10; -*-
 
 ;;;; * Introduction
 

--- a/src/random.lisp
+++ b/src/random.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: FIVEAM; Base: 10; -*-
 
 (in-package :it.bese.fiveam)
 


### PR DESCRIPTION
Genera doesn't handle (in-package ...) the way that most people expect, but instead uses the Package file attribute to determine which package to place definitions into. This is easily fixed by adding a comment line like this:
```lisp
;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: <package-name> -*-
```
at the top of the file, with no change to the lisp code required.