### PR TITLE
SIGNAL a condition on test failures, for use with ASDF:TEST-SYSTEM

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -79,7 +79,8 @@
    #:*on-failure*
    #:*verbose-failures*
    #:*print-names*
-   #:results-status))
+   #:results-status
+   #:test-spec-failure))
 
 ;;;; You can use #+5am to put your test-defining code inline with your
 ;;;; other code - and not require people to have fiveam to run your

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -266,6 +266,37 @@ run."))
   (when-let (test (get-test test-name))
     (%run test)))
 
+(define-condition test-spec-failure (warning)
+  ((test-spec :initarg :test-spec
+              :reader  test-spec-failure-spec))
+  (:documentation
+   "Superclass of conditions signalled by RUN to indicate test failures.
+Intended for use with ASDF:TEST-SYSTEM"))
+
+(define-condition test-spec-failure-no-tests (test-spec-failure) ()
+  (:documentation
+   "Condition to indicate that the given test spec did not result in any tests being run.
+See also documentation for parent condition TEST-SPEC-FAILURE")
+  (:report
+   (lambda (condition stream)
+     (write-string "Error: no tests ran for test spec: " stream)
+     (prin1 (test-spec-failure-spec condition) stream))))
+
+(define-condition test-spec-failure-tests-failed (test-spec-failure)
+    ((result-list :initarg :result-list
+                  :reader  test-spec-failure-result-list))
+  (:documentation "Condition to indicate that the given test spec has one or more failing tests.
+See also documentation for parent condition TEST-SPEC-FAILURE")
+  (:report
+   (lambda (condition stream)
+     (write-string "Failing tests in test spec " stream)
+     (prin1 (test-spec-failure-spec condition) stream)
+     (terpri stream)
+     (let ((*print-names*  nil)
+           (*test-dribble* stream))
+       (explain!
+        (test-spec-failure-result-list condition))))))
+
 (defvar *initial-!* (lambda () (format t "Haven't run that many tests yet.~%")))
 
 (defvar *!* *initial-!*)
@@ -319,7 +350,21 @@ performed by the !, !! and !!! functions."
                             (format *test-dribble* "*DEBUG-ON-FAILURE* is obsolete. Use *ON-FAILURE*.")
                             :debug)
                            (t nil)))))
-    (funcall *!*)))
+    (let ((result-list (funcall *!*)))
+      (multiple-value-bind (all-pass? failed skipped)
+          (results-status result-list)
+        (declare (ignore failed))
+        (with-simple-restart
+            (continue "Here so FiveAM can asdf:test-system itself")
+          (cond
+            ((= (length result-list) (length skipped))
+             (signal 'test-spec-failure-no-tests
+                     :test-spec test-spec))
+            ((not all-pass?)
+             (signal 'test-spec-failure-tests-failed
+                     :test-spec test-spec
+                     :result-list result-list)))))
+      result-list)))
 
 (defun ! ()
   "Rerun the most recently run test and explain the results."


### PR DESCRIPTION
Hello!

I recently wrote a script to run FiveAM tests for one of my
libraries on many different implementations on your own machine:
https://gitlab.common-lisp.net/uri-template/uri-template2/blob/master/run-tests.lisp

I do not want to copy-paste that script for all of my libraries. It
would be nice to contribute a generalized version of the script to
Roswell (on which the script is based), and just be able to say "ros
test my-system in all installed implementations" for any system.

The first step to doing that is to get ASDF:TEST-SYSTEM to report
errors using a common interface.

Because of the way ASDF is designed, ASDF:TEST-SYSTEM needs to use
conditions to signal test failures. I like this idea. Since you do
not have to handle conditions raised by SIGNAL, the functionality can
be added without impacting existing use or interfaces of FiveAM (the
use of WARNING instead of ERROR as the parent condition of
TEST-SPEC-FAILURE also ensures this, as many people tend to abuse
HANDLER-CASE to indiscriminately catch ERRORs).

With this patch, all projects that use FiveAM and define ASDF test-op
should be testable from a generic version of the Roswell script
without any changes.

The basic mechanism for test automation with FiveAM is then very
simple:

(handler-case (asdf:test-system "system")
  (fiveam:test-spec-failure (condition)
    (princ condition uiop:*stderr*)
    (uiop:quit 1)))

Other test libraries can have supported added as well:

(handler-case (asdf:test-system "system")
  ((or fiveam:test-spec-failure prove:test-failure) (condition)
    (princ condition uiop:*stderr*)
    (uiop:quit 1)))

The goal is to introduce a parent condition in ASDF that FiveAM, etc., will then inherit from:

(handler-case (asdf:test-system "system")
  (asdf:test-failure (condition)
    (princ condition uiop:*stderr*)
    (uiop:quit 1)))

Ultimately, any system using any test library should be testable this way, ensuring that test automation becomes trivial to build.

I am going to propose adding the parent condition to ASDF, but in the
meantime (until the ASDF patch makes it to the repository, another
release comes out, release becomes widely available…), I would like to get this code into FiveAM.

Vladimir