### PR TITLE
Print suite name in explain

### DIFF
--- a/src/classes.lisp
+++ b/src/classes.lisp
@@ -54,7 +54,11 @@ suite) in the suite."))
   ((test-lambda :initarg :test-lambda :accessor test-lambda
                 :documentation "The function to run.")
    (runtime-package :initarg :runtime-package :accessor runtime-package
-                    :documentation "By default it stores *package* from the time this test was defined (macroexpanded)."))
+                    :documentation "By default it stores *package* from the time this test was defined (macroexpanded).")
+   (test-suite :initarg :test-suite
+               :accessor test-suite
+               :initform nil
+               :documentation "The test-suite associated with this test"))
   (:documentation "A test case is a single, named, collection of
 checks.
 

--- a/src/explain.lisp
+++ b/src/explain.lisp
@@ -42,8 +42,12 @@
         (output "Failure Details:~%")
         (dolist (f (reverse failed))
           (output "--------------------------------~%")
-          (output "~A ~@{[~A]~}: ~%"
+          (output "~A ~A~@{[~A]~}: ~%"
                   (name (test-case f))
+                  (let ((suite (name (test-suite (test-case f)))))
+                    (if suite
+                        (format nil "in ~A " suite)
+                        ""))
                   (description (test-case f)))
           (output "     ~A.~%" (reason f))
           (when (for-all-test-failed-p f)

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -130,7 +130,8 @@ If PROFILE is T profiling information will be collected as well."
                                  (:definition-time body))))
                          :description description
                          :depends-on depends-on
-                         :collect-profiling-info profile))
+                         :collect-profiling-info profile
+                         :test-suite suite))
     (setf (gethash name (tests suite)) name)))
 
 (defvar *run-test-when-defined* nil


### PR DESCRIPTION
When running a large number of tests (say in CI), and a test fails, it becomes hard to tell where the test is located (especially if it's a generically named test like "test-preconditions" or "test-happy-path").

The suite will help a little bit.