### PR TITLE
Don't add a name when it's already defined.

### DIFF
--- a/src/test.lisp
+++ b/src/test.lisp
@@ -28,7 +28,7 @@
   (gethash key (%tests *test*) default))
 
 (defun (setf get-test) (value key)
-  (push key (%test-names *test*))
+  (pushnew key (%test-names *test*))
   (setf (gethash key (%tests *test*)) value))
 
 (defun rem-test (key)


### PR DESCRIPTION
This can potentially be a memory leak if a code keeps adding tests.