### PR TITLE
Control source registry of Lisp docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
           - l: abcl
             IMAGE_TAG: 1.7.1-jdk8 # FIXME: this is likely obsolete
             PREFIX: containers.common-lisp.net/cl-docker-images
-
+          - l: abcl
+            IMAGE_TAG: 1.9.0
+            PREFIX: docker.io/rpgoldman
     env:
       GITHUB_ACTION: true
       I_AGREE_TO_ALLEGRO_EXPRESS_LICENSE: yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,14 +90,20 @@ jobs:
       continue-on-error: true
 
     - name: save build output
-      uses: actions/upload-artifact@v3
+      id: save-build-output
+      uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.l}}-${{matrix.IMAGE_TAG}}-build-output.text
         path: build/results/${{matrix.l}}-load.text
 
+    - name: return build output id
+      run: |
+        echo 'Artifact ID is ${{ steps.save-build-output.outputs.artifact-id }}'
+
     - name: build fail
       if: ${{ steps.test-build.outcome == 'failure'}}
-      run: false
+      run: 
+        /usr/bin/false
 
     - name: tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
           - l: abcl
             IMAGE_TAG: 1.7.1-jdk8 # FIXME: this is likely obsolete
             PREFIX: containers.common-lisp.net/cl-docker-images
-          - l: abcl
-            IMAGE_TAG: 1.9.0
-            PREFIX: docker.io/rpgoldman
     env:
       GITHUB_ACTION: true
       I_AGREE_TO_ALLEGRO_EXPRESS_LICENSE: yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: containers.common-lisp.net/cl-docker-images/${{matrix.l}}:${{matrix.IMAGE_TAG}}
+      image: ${{matrix.PREFIX}}/${{matrix.l}}:${{matrix.IMAGE_TAG}}
 
     strategy:
       matrix:
@@ -26,16 +26,35 @@ jobs:
         # just going to try to get ONE lisp to work first
         # can't run CMUCL on GitHub actions.
         # ccl's ASDF seems to be having trouble with source initialization 
-        l: [abcl, allegro, clisp, ecl, sbcl] # ccl, cmucl (probably not the last).
+        l: [abcl, allegro11express, clisp, ecl, ccl, sbcl] # ccl, cmucl (probably not the last).
         IMAGE_TAG: [latest]
+        PREFIX:
+          - containers.common-lisp.net/cl-docker-images
+          - docker.io/rpgoldman
+        exclude:
+          - l: allegro11express
+            PREFIX: containers.common-lisp.net/cl-docker-images
+          - l: sbcl
+            PREFIX: containers.common-lisp.net/cl-docker-images
+          - l: ccl
+            PREFIX: containers.common-lisp.net/cl-docker-images
+          - l: abcl
+            PREFIX: containers.common-lisp.net/cl-docker-images            
+          - l: clisp
+            PREFIX: docker.io/rpgoldman   
+          - l: ecl
+            PREFIX: docker.io/rpgoldman             
         include:
           - l: clasp
             IMAGE_TAG: "b14e329f49998275579926da2a737885ceb2cea7"
-          - l: allegro
+            PREFIX: containers.common-lisp.net/cl-docker-images
+          - l: allegro11express
             IMAGE_TAG: latest
             variant: modern
+            PREFIX: docker.io/rpgoldman
           - l: abcl
             IMAGE_TAG: 1.7.1-jdk8 # FIXME: this is likely obsolete
+            PREFIX: containers.common-lisp.net/cl-docker-images
 
     env:
       GITHUB_ACTION: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,15 +83,21 @@ jobs:
 
     - name: test build
       shell: bash
+      id: test-build
       run: |
         ./run-tests.sh -c ${{ matrix.l }} || ${{ matrix.l == 'clisp' }}
         # no idea how to get FiveAM to build clean on clisp
+      continue-on-error: true
 
     - name: save build output
       uses: actions/upload-artifact@v3
       with:
         name: ${{matrix.l}}-${{matrix.IMAGE_TAG}}-build-output.text
         path: build/results/${{matrix.l}}-load.text
+
+    - name: build fail
+      if: ${{ steps.test-build.outcome == 'failure'}}
+      run: false
 
     - name: tests
       shell: bash

--- a/build.lisp
+++ b/build.lisp
@@ -57,7 +57,7 @@
                 (error #'(lambda (x)
                            (setf *build-error* x)
                            (throw 'build-failed t))))
-   (asdf:load-system "fiveam" :force :all)))
+   (asdf:load-system "fiveam" :force t)))
 
 (cond
   (*build-error*

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,6 +16,7 @@ usage () {
     echo "    allegro_s, allegro8_s, allegromodern_s, allegromodern8_s (SMP variants)"
     echo "    allegro_64, allegro8_64, allegromodern_64, allegromodern8_64 (64-bit variants),"
     echo "    allegro_64_s, allegro8_64_s, allegromodern_64_s, allegromodern8_64_s, (SMP, 64-bit variants)"
+    echo "    allegro11express (for docker image)"
     echo "    clasp, clisp, cmucl, ecl, gcl, sbcl, scl and xcl."
     echo " To configure the script, you may set environment variables to point to the various lisp runtimes."
     echo " Allegro CL is a special case: instead of setting environment variables for the specific runtime"
@@ -152,6 +153,7 @@ case "$lisp" in
     ;;
   allegro*)
     case "$lisp" in
+      allegro11express) command="${ALLEGRO:-alisp}" ;;
       allegro) command="${ALLEGRO:-alisp}" ;;
       allegro8) command="${ALLEGRO8:-alisp8}" ;;
       allegromodern) command="${ALLEGROMODERN:-mlisp}" ;;


### PR DESCRIPTION
Because the cl-foundation docker image registry is no longer maintained, substitute in docker images from my personal repo on DockerHub.